### PR TITLE
Add homing spam for Shadow, TGS-faithful Chaos Smash

### DIFF
--- a/.git-repo
+++ b/.git-repo
@@ -12,6 +12,7 @@ https://raw.githubusercontent.com/Knuxfan24/Sonic-06-Mod-Manager-Patches/master/
 https://raw.githubusercontent.com/Knuxfan24/Sonic-06-Mod-Manager-Patches/master/DisableFramebufferEffects.mlua
 https://raw.githubusercontent.com/Knuxfan24/Sonic-06-Mod-Manager-Patches/master/DisableShadows.mlua
 https://raw.githubusercontent.com/Knuxfan24/Sonic-06-Mod-Manager-Patches/master/EnableChaosSmash.mlua
+https://raw.githubusercontent.com/Knuxfan24/Sonic-06-Mod-Manager-Patches/master/EnableChaosSmashTGS.mlua
 https://raw.githubusercontent.com/Knuxfan24/Sonic-06-Mod-Manager-Patches/master/EnableHomingFlips.mlua
 https://raw.githubusercontent.com/Knuxfan24/Sonic-06-Mod-Manager-Patches/master/EnableHomingSpam.mlua
 https://raw.githubusercontent.com/Knuxfan24/Sonic-06-Mod-Manager-Patches/master/HomingRecoveryControl.mlua

--- a/EnableChaosSmashTGS.mlua
+++ b/EnableChaosSmashTGS.mlua
@@ -1,0 +1,8 @@
+--[[Patch]]--
+Title("Enable Chaos Smash (TGS-faithful)")
+Author("Desko")
+Platform("Xbox 360")
+Blurb("This patch will restore Shadow's Chaos Smash. Hold A to charge the attack, and release to knock enemies into each other.\n\nUnlike the other version, you can only chain partially charged homing attacks, as with the TGS 2006 demo.")
+
+--[[Functions]]--
+WriteByte("default.xex"|0x1A8FD7|0x55)

--- a/EnableHomingSpam.mlua
+++ b/EnableHomingSpam.mlua
@@ -2,11 +2,11 @@
 Title("Enable Homing Spam")
 Author("Desko")
 Platform("Xbox 360")
-Blurb("Allows the player to spam Sonic's homing attack.")
+Blurb("Allows the player to spam Sonic and Shadow's homing attacks.")
 Description("This patch will restore homing spam from the E3 demo.")
 
 --[Functions]--
 DecryptXEX("default.xex")
 DecompressXEX("default.xex")
-WriteNopPPC("default.xex"|0x21A4BC)
 WriteByte("default.xex"|0x21A5D8|0x40)
+WriteByte("default.xex"|0x1A98AC|0x40)

--- a/HomingRecoveryControl.mlua
+++ b/HomingRecoveryControl.mlua
@@ -3,7 +3,7 @@ Title("Homing Recovery Control")
 Author("Desko")
 Platform("Xbox 360")
 Blurb("Unlocks mid-air control for Sonic's homing attack recovery.")
-Description("This patch will unlock mid-air control for the full duration of Sonic's homing recovery.\n\nUnlock Mid-air Momentum patch would be recommended to use with this.")
+Description("This patch will unlock mid-air control for the full duration of Sonic's homing recovery.\n\nEnable Homing Spam is highly recommended for full control, as otherwise you will be unable to turn at the start of the move. Use of the Unlock Mid-air Momentum patch is also suggested.")
 
 --[Functions]--
 DecryptXEX("default.xex")


### PR DESCRIPTION
Also cleans up the homing spam patch itself, as the nop is no longer necessary. The updated homing spam patch will also give Shadow full directional control after the move, as is the case with Sonic, though you'd need to remove the Chaos Attack delay for "true" spam.