### PR TITLE
Fix TGS Chaos Smash patch, add invincibility and high speed patches

### DIFF
--- a/.git-repo
+++ b/.git-repo
@@ -1,4 +1,6 @@
 https://raw.githubusercontent.com/Knuxfan24/Sonic-06-Mod-Manager-Patches/master/ActionGaugeFixes.mlua
+https://raw.githubusercontent.com/Knuxfan24/Sonic-06-Mod-Manager-Patches/master/AlwaysHaveHighSpeed.mlua
+https://raw.githubusercontent.com/Knuxfan24/Sonic-06-Mod-Manager-Patches/master/AlwaysHaveInvincibility.mlua
 https://raw.githubusercontent.com/Knuxfan24/Sonic-06-Mod-Manager-Patches/master/BoardCollisionAnimFix.mlua
 https://raw.githubusercontent.com/Knuxfan24/Sonic-06-Mod-Manager-Patches/master/BoundAttackRecovery.mlua
 https://raw.githubusercontent.com/Knuxfan24/Sonic-06-Mod-Manager-Patches/master/ControllableSpinkick.mlua

--- a/AlwaysHaveHighSpeed.mlua
+++ b/AlwaysHaveHighSpeed.mlua
@@ -1,0 +1,11 @@
+--[[Patch]]--
+Title("Always Have High Speed")
+Author("Desko")
+Platform("Xbox 360")
+Blurb("Gives characters the High Speed powerup at all times.")
+Description("This patch will give all main characters the High Speed power up at all times, boosting their speed.")
+
+--[[Functions]]--
+DecryptExecutable()
+DecompressExecutable()
+WriteNopPPC(Executable|0x20FBFC)

--- a/AlwaysHaveInvincibility.mlua
+++ b/AlwaysHaveInvincibility.mlua
@@ -1,0 +1,11 @@
+--[[Patch]]--
+Title("Always Have Invincibility")
+Author("Desko")
+Platform("Xbox 360")
+Blurb("Gives characters invincibility at all times.")
+Description("This patch will give all main characters invincibility at all times.")
+
+--[[Functions]]--
+DecryptExecutable()
+DecompressExecutable()
+WriteNopPPC(Executable|0x20FBE4)

--- a/EnableChaosSmashTGS.mlua
+++ b/EnableChaosSmashTGS.mlua
@@ -6,4 +6,6 @@ Blurb("This patch will restore Shadow's Chaos Smash to be more like TGS 2006.")
 Description("This patch will restore Shadow's Chaos Smash.\n\nHold A to charge the attack, and release to knock enemies into each other.\n\nUnlike the other version, you can only chain partially charged homing attacks, as with the TGS 2006 demo.")
 
 --[[Functions]]--
+DecryptExecutable()
+DecompressExecutable()
 WriteByte(Executable|0x1A8FD7|0x55)


### PR DESCRIPTION
Fixed the TGS Chaos Smash patch not decrypting and decompressing the xex, and added Always Have Invicibility and High Speed (Power Sneakers) patches.